### PR TITLE
Fixes Anomalites' Carpal Tunnel

### DIFF
--- a/Resources/Prototypes/_Betelgeuse/Body/Prototypes/Animal/anomalous.yml
+++ b/Resources/Prototypes/_Betelgeuse/Body/Prototypes/Animal/anomalous.yml
@@ -1,0 +1,32 @@
+- type: body
+  id: Anomalous
+  name: "animal"
+  root: torso
+  slots:
+    head:
+      part: HeadHuman
+      connections:
+      - torso
+    torso:
+      part: TorsoAnimal
+      connections:
+      - right arm
+      - left arm
+      organs:
+        lungs: OrganAnimalLungs
+        stomach: OrganAnimalStomach
+        liver: OrganAnimalLiver
+        heart: OrganAnimalHeart
+        kidneys: OrganAnimalKidneys
+    right arm:
+      part: RightArmHuman
+      connections:
+      - right hand
+    left arm:
+      part: LeftArmHuman
+      connections:
+      - left hand
+    right hand:
+      part: RightHandHuman
+    left hand:
+      part: LeftHandHuman

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Anomalites/anomalites.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Anomalites/anomalites.yml
@@ -31,7 +31,7 @@
     factions:
     - SimpleNeutral
   - type: Body
-    prototype: Animal
+    prototype: Anomalous # Betelgeuse - No legs, but a torso, arms, and head
   - type: Damageable # DeltaV - Change their damage to BiologicalMetaphysical, since they're magical sprite things. Also the shadow anomalite is supposed to take holy damage and it can't normally
     damageContainer: BiologicalMetaphysical
   - type: Dispellable # DeltaV - they're anomalies so they should be dispellable

--- a/Resources/Prototypes/_Impstation/InventoryTemplates/anomalite_inventory_template.yml
+++ b/Resources/Prototypes/_Impstation/InventoryTemplates/anomalite_inventory_template.yml
@@ -12,3 +12,12 @@
       dependsOn: jumpsuit
       displayName: Pocket 1
       stripHidden: true
+          # Begin Betelgeuse edit.
+    - name: head
+      slotTexture: head
+      slotFlags: HEAD
+      uiWindowPos: 1,3
+      strippingWindowPos: 1,0
+      displayName: Head
+      offset: 0,-0.188
+      # End Betelgeuse edit.


### PR DESCRIPTION
## About the PR
Anomalites were added with _hands_ but no **Hands** among other issues (such as the core tracker not functioning)
This just lets them use their hands, and gives them a hat slot for individual expression from our horrifying friends who were debatably trying to murder the station until Epi hit their house with an A.P.E.
## Why / Balance
A small friend that previously was missing its hands now has its hands and all that entails (guns cause comedic recoil, and they are too floaty to really efficiently dodge in melee, BUT, they can now do your taxes), and a hat slot (which could be used for fashion OR lighting)

## Technical details
The Anomalite Prototype's body type has been changed to a new one, Anomalous, that has arms + hands, and a head.
The Anomalite Inventory template has been given a hat slot, which will allow the anomalite and other players to put silly hats on them. Due to how the offsets work (**WHY** IS IT IN _TILES_), it is difficult to line it up pixel-perfectly, so they will have a very minute offset from the Anomalite's pixel grid, unfortunately.

## Media
<img width="124" height="126" alt="image" src="https://github.com/user-attachments/assets/3d015f9e-1261-4667-981b-315e62b5acc3" />
<img width="100" height="129" alt="image" src="https://github.com/user-attachments/assets/96b67a51-b01d-49fb-b013-0d1211bcc50d" />
<img width="127" height="132" alt="image" src="https://github.com/user-attachments/assets/a85a5ebc-efe4-47d1-adce-e0ce74bc494a" />
<img width="387" height="408" alt="image" src="https://github.com/user-attachments/assets/09b753df-7f44-4546-8531-88a583e4e83d" />

## Requirements

- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Added hat slot to Anomalites so they can be enfashioned by their core carrier and themself (if allowed)
- fix: Anomalites' body now has hands, allowing them to actually use their hands.
