### PR TITLE
Restores HoP access

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -35,26 +35,30 @@
   - Janitor
   - Theatre
   - Kitchen
-  #- Chapel # DeltaV - Chapel is in Epistemics
+  - Clerk
+  - Chapel # DeltaV - Chapel is in Epistemics
   - Hydroponics
   - External
   - Cryogenics
-  # I mean they'll give themselves the rest of the access levels *anyways*.
-  # As of 15/03/23 they can't do that so here's MOST of the rest of the access levels.
-  # Head level access that isn't their own was deliberately left out, get AA from the captain instead.
-  # Begin DeltaV Removals - fuck all of this HoP is a service role
-  #- Chemistry
-  #- Engineering
-  #- Research
-  #- Detective
-  #- Salvage
-  #- Security # NoooOoOo!! My HoPcurity!1
-  #- Brig
-  #- Lawyer # Lawyer is now part of the justice dept
-  #- Cargo
-  #- Atmospherics
-  #- Medical
-  # End DeltaV Removals
+  - Chemistry
+  - Engineering
+  - Research
+  - Mantis
+  - Robotics
+  - Detective
+  - Salvage
+  - Mail
+  - Security
+  - Corpsman
+  - Brig
+  # Lawyer # we're removing law and replacing it with IA, don't make anyone a lawyer
+  - Cargo
+  - Orders
+  - Atmospherics
+  - Medical
+  - Paramedic
+  - Psychologist
+  - Surgery
   # Begin DeltaV Additions - fine-grained service accesses
   - Boxer
   - Clown

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -51,6 +51,7 @@
   - Security
   - Corpsman
   - Brig
+  - Armory
   # Lawyer # we're removing law and replacing it with IA, don't make anyone a lawyer
   - Cargo
   - Orders


### PR DESCRIPTION
## About the PR
Once again makes the Head of Personnel capable of managing... the personnel. Restores their access to each of the departments and allows them to promote/demote crew as needed.

## Why / Balance
Having HoP be the "service head" is useless and they get to do nothing interesting compared to the other command staff. They are not "captain lite" but still should be allowed to do something that no one else in the department can do, again much like other command staff. They do not have _all_ access however, only _most_ access. They cannot promote anyone to a command role, this must be done by the Captain. It's also worth noting that although you may have access to each of the departments, that doesn't necessarily mean you are allowed there, and security can still slap you for trespassing into a restricted area. At the end of the day you are also still the Service head, and all Service employees are still under your direct supervision and command.

## Media
![A preview of the access the HoP can once again grant](https://i.imgur.com/PvH62ah.png)
_As a note, I took this picture before I decided to allow HoP access to the armory, and armory access is part of the final commits. I was just too lazy to retake it._

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The Head of Personnel can once again promote/demote crew
